### PR TITLE
Upload file from stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "md5",
  "mime",
  "mime_guess",
+ "mktemp",
  "rustc_version_runtime",
  "serde",
  "serde_json",
@@ -437,6 +438,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -816,6 +828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mktemp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bdc1f74dd7bb717d39f784f844e490d935b3aa7e383008006dbbf29c1f7820a"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,7 +993,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -995,7 +1016,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1540,6 +1561,15 @@ dependencies = [
  "form_urlencoded",
  "idna 0.3.0",
  "percent-encoding 2.2.0",
+]
+
+[[package]]
+name = "uuid"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+dependencies = [
+ "getrandom 0.2.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ hyper = { version = "0.14.23", features = ["stream"] }
 md5 = "0.7.0"
 mime = "0.3.16"
 mime_guess = "2.0.4"
+mktemp = "0.5.0"
 rustc_version_runtime = "0.2.1"
 serde = { version = "1.0.151", features = ["derive"] }
 serde_json = "1.0.89"

--- a/src/common/file_helper.rs
+++ b/src/common/file_helper.rs
@@ -11,10 +11,17 @@ pub fn stdin_to_file() -> Result<Temp, io::Error> {
     Ok(tmp_file)
 }
 
-pub fn open_file(path: &PathBuf) -> Result<File, io::Error> {
-    if PathBuf::from("-") == *path {
-        File::open(stdin_to_file()?)
-    } else {
-        File::open(path)
+pub fn open_file(path: &Option<PathBuf>) -> Result<(File, PathBuf), io::Error> {
+    match path {
+        Some(path) => {
+            let file = File::open(path)?;
+            Ok((file, path.clone()))
+        },
+        None => {
+            let tmp_file = stdin_to_file()?;
+            let path = tmp_file.as_ref().to_path_buf();
+            let file = File::open(&path)?;
+            Ok((file, path))
+        }
     }
 }

--- a/src/common/file_helper.rs
+++ b/src/common/file_helper.rs
@@ -1,0 +1,20 @@
+use std::io;
+use std::fs::File;
+use std::path::PathBuf;
+use mktemp::Temp;
+
+pub fn stdin_to_file() -> Result<Temp, io::Error> {
+    let tmp_file = Temp::new_file()?;
+    let path = tmp_file.as_ref().to_path_buf();
+    let mut file = File::create(&path)?;
+    io::copy(&mut io::stdin(), &mut file)?;
+    Ok(tmp_file)
+}
+
+pub fn open_file(path: &PathBuf) -> Result<File, io::Error> {
+    if PathBuf::from("-") == *path {
+        File::open(stdin_to_file()?)
+    } else {
+        File::open(path)
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -10,3 +10,4 @@ pub mod id_gen;
 pub mod md5_writer;
 pub mod permission;
 pub mod table;
+pub mod file_helper;

--- a/src/files/update.rs
+++ b/src/files/update.rs
@@ -4,6 +4,7 @@ use crate::common::delegate::UploadDelegate;
 use crate::common::delegate::UploadDelegateConfig;
 use crate::common::file_info;
 use crate::common::file_info::FileInfo;
+use crate::common::file_helper;
 use crate::common::hub_helper;
 use crate::files;
 use crate::files::info;
@@ -13,7 +14,6 @@ use mime::Mime;
 use std::error;
 use std::fmt::Display;
 use std::fmt::Formatter;
-use std::fs;
 use std::io;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -41,7 +41,7 @@ pub async fn update(config: Config) -> Result<(), Error> {
         print_chunk_info: config.print_chunk_info,
     };
 
-    let file = fs::File::open(&config.file_path)
+    let file = file_helper::open_file(&config.file_path)
         .map_err(|err| Error::OpenFile(config.file_path.clone(), err))?;
 
     let drive_file = info::get_file(&hub, &config.file_id)

--- a/src/files/update.rs
+++ b/src/files/update.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 pub struct Config {
     pub file_id: String,
-    pub file_path: PathBuf,
+    pub file_path: Option<PathBuf>,
     pub mime_type: Option<Mime>,
     pub chunk_size: ChunkSize,
     pub print_chunk_errors: bool,
@@ -41,8 +41,9 @@ pub async fn update(config: Config) -> Result<(), Error> {
         print_chunk_info: config.print_chunk_info,
     };
 
-    let file = file_helper::open_file(&config.file_path)
-        .map_err(|err| Error::OpenFile(config.file_path.clone(), err))?;
+    let (file, file_path) = file_helper::open_file(&config.file_path)
+        .map_err(|err| Error::OpenFile(
+            config.file_path.unwrap_or_else(|| PathBuf::from("<stdin>")), err))?;
 
     let drive_file = info::get_file(&hub, &config.file_id)
         .await
@@ -51,7 +52,7 @@ pub async fn update(config: Config) -> Result<(), Error> {
     let file_info = FileInfo::from_file(
         &file,
         &file_info::Config {
-            file_path: config.file_path.clone(),
+            file_path: file_path.clone(),
             mime_type: config.mime_type,
             parents: drive_file.parents.clone(),
         },
@@ -63,7 +64,7 @@ pub async fn update(config: Config) -> Result<(), Error> {
     println!(
         "Updating {} with {}",
         config.file_id,
-        config.file_path.display()
+        file_path.display()
     );
 
     let file = update_file(&hub, reader, &config.file_id, file_info, delegate_config)

--- a/src/files/upload.rs
+++ b/src/files/upload.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 pub struct Config {
-    pub file_path: PathBuf,
+    pub file_path: Option<PathBuf>,
     pub mime_type: Option<Mime>,
     pub parents: Option<Vec<String>>,
     pub chunk_size: ChunkSize,
@@ -48,23 +48,26 @@ pub async fn upload(config: Config) -> Result<(), Error> {
         print_chunk_info: config.print_chunk_info,
     };
 
-    if PathBuf::from("-") == config.file_path {
-        let tmp_file = file_helper::stdin_to_file()
-            .map_err(|err| Error::OpenFile(config.file_path.clone(), err))?;
+    match &config.file_path {
+        Some(path) => {
+            err_if_directory(&path, &config)?;
 
-        upload_regular(&hub, &Config {
-            file_path: tmp_file.as_ref().to_path_buf(),
-            ..config
-        }, delegate_config).await?;
-    } else {
-        err_if_directory(&config.file_path, &config)?;
+            if path.is_dir() {
+                upload_directory(&hub, &config, delegate_config).await?;
+            } else {
+                upload_regular(&hub, &config, delegate_config).await?;
+            }
+        },
+        None => {
+            let tmp_file = file_helper::stdin_to_file()
+                .map_err(|err| Error::OpenFile(PathBuf::from("<stdin>"), err))?;
 
-        if config.file_path.is_dir() {
-            upload_directory(&hub, &config, delegate_config).await?;
-        } else {
-            upload_regular(&hub, &config, delegate_config).await?;
+            upload_regular(&hub, &Config {
+                file_path: Some(tmp_file.as_ref().to_path_buf()),
+                ..config
+            }, delegate_config).await?;
         }
-    }
+    };
 
     Ok(())
 }
@@ -74,13 +77,14 @@ pub async fn upload_regular(
     config: &Config,
     delegate_config: UploadDelegateConfig,
 ) -> Result<(), Error> {
-    let file = fs::File::open(&config.file_path)
-        .map_err(|err| Error::OpenFile(config.file_path.clone(), err))?;
+    let file_path = config.file_path.as_ref().unwrap();
+    let file = fs::File::open(file_path)
+        .map_err(|err| Error::OpenFile(file_path.clone(), err))?;
 
     let file_info = FileInfo::from_file(
         &file,
         &file_info::Config {
-            file_path: config.file_path.clone(),
+            file_path: file_path.clone(),
             mime_type: config.mime_type.clone(),
             parents: config.parents.clone(),
         },
@@ -90,7 +94,7 @@ pub async fn upload_regular(
     let reader = std::io::BufReader::new(file);
 
     if !config.print_only_id {
-        println!("Uploading {}", config.file_path.display());
+        println!("Uploading {}", file_path.display());
     }
 
     let file = upload_file(&hub, reader, None, file_info, delegate_config)
@@ -114,7 +118,7 @@ pub async fn upload_directory(
     delegate_config: UploadDelegateConfig,
 ) -> Result<(), Error> {
     let mut ids = IdGen::new(hub, &delegate_config);
-    let tree = FileTree::from_path(&config.file_path, &mut ids)
+    let tree = FileTree::from_path(config.file_path.as_ref().unwrap(), &mut ids)
         .await
         .map_err(Error::CreateFileTree)?;
 
@@ -166,7 +170,7 @@ pub async fn upload_directory(
 
         for file in folder.files() {
             let os_file = fs::File::open(&file.path)
-                .map_err(|err| Error::OpenFile(config.file_path.clone(), err))?;
+                .map_err(|err| Error::OpenFile(config.file_path.as_ref().unwrap().clone(), err))?;
 
             let file_info = file.info(parents.clone());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ enum FileCommand {
     /// Upload file
     Upload {
         /// Path of file to upload
-        file_path: PathBuf,
+        file_path: Option<PathBuf>,
 
         /// Force mime type [default: auto-detect]
         #[arg(long, value_name = "MIME_TYPE")]
@@ -220,7 +220,7 @@ enum FileCommand {
         file_id: String,
 
         /// Path of file to upload
-        file_path: PathBuf,
+        file_path: Option<PathBuf>,
 
         /// Force mime type [default: auto-detect]
         #[arg(long, value_name = "MIME_TYPE")]


### PR DESCRIPTION
To address the OP's request in #23, I incorporated specialized logic for when the file path is `-`. This logic interrupts the existing control flow, copies stdin's contents to a temporary file, and forwards its file path to the following steps when uploading or updating.