### PR TITLE
FIX --max parameter when listing files

### DIFF
--- a/src/files/list.rs
+++ b/src/files/list.rs
@@ -31,7 +31,7 @@ pub async fn list(config: Config) -> Result<(), Error> {
         &ListFilesConfig {
             query: config.query.clone(),
             order_by: config.order_by.clone(),
-            max_files: min(config.max_files, MAX_PAGE_SIZE),
+            max_files: config.max_files,
         },
     )
     .await?;


### PR DESCRIPTION
Here MAX_PAGE_SIZE should only be used to retrieve the target file list in batches but not for limiting the maximum amount of files to list.