### PR TITLE
Add support for determining folder size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,9 @@ enum FileCommand {
         /// Field separator
         #[arg(long, default_value_t = String::from("\t"))]
         field_separator: String,
+
+        #[arg(long)]
+        folder_size: bool
     },
 
     /// Download file
@@ -471,6 +474,7 @@ async fn main() {
                     skip_header,
                     full_name,
                     field_separator,
+                    folder_size
                 } => {
                     let parent_query =
                         parent.map(|folder_id| ListQuery::FilesInFolder { folder_id });
@@ -486,6 +490,7 @@ async fn main() {
                         skip_header,
                         truncate_name: !full_name,
                         field_separator,
+                        folder_size
                     })
                     .await
                     .unwrap_or_else(handle_error)


### PR DESCRIPTION
By using `FileTreeDrive::from_file`, the `file list` command determines the folder size (with the --folder-size option)