### PR TITLE
Release builds for ARM architectures

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+# use the correct linker for cross compiling to ARM
+[target.armv7-unknown-linux-musleabihf]
+linker = "rust-lld"
+
+[target.arm-unknown-linux-musleabi]
+linker = "rust-lld"
+
+[target.aarch64-unknown-linux-musl]
+linker = "rust-lld"
+

--- a/.github/workflows/release_linux_aarch64.yaml
+++ b/.github/workflows/release_linux_aarch64.yaml
@@ -1,4 +1,4 @@
-name: Build and upload release (linux x86_64)
+name: Build and upload release (linux aarch64)
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
 
 env:
   APP_NAME: gdrive
-  ARCHIVE_NAME: gdrive_linux-x64.tar.gz
+  ARCHIVE_NAME: gdrive_linux-aarch64.tar.gz
 
 jobs:
   build:
@@ -21,13 +21,20 @@ jobs:
           UPLOAD_URL="$(jq -r '.release.upload_url' "$GITHUB_EVENT_PATH" | sed -e "s/{?name,label}$/?name=${ARCHIVE_NAME}/")"
           echo "UPLOAD_URL=$UPLOAD_URL" >> $GITHUB_ENV
 
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: aarch64-unknown-linux-musl
+
       - name: Build application
         run: |
-          docker run --rm -t -v $HOME/.cargo/registry/:/root/.cargo/registry -v "$(pwd)":/volume clux/muslrust:stable cargo build --release
+          sudo apt update && sudo apt install -y clang llvm
+          export TARGET_CC=clang
+          export TARGET_AR=llvm-ar
+          cargo build --release --target=aarch64-unknown-linux-musl
 
       - name: Create archive
         run: |
-          tar -czf $ARCHIVE_NAME -C target/x86_64-unknown-linux-musl/release $APP_NAME
+          tar -czf $ARCHIVE_NAME -C target/aarch64-unknown-linux-musl/release $APP_NAME
 
       - name: Upload release asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release_linux_arm.yaml
+++ b/.github/workflows/release_linux_arm.yaml
@@ -1,4 +1,4 @@
-name: Build and upload release (linux x86_64)
+name: Build and upload release (linux arm 32bit)
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
 
 env:
   APP_NAME: gdrive
-  ARCHIVE_NAME: gdrive_linux-x64.tar.gz
+  ARCHIVE_NAME: gdrive_linux-arm.tar.gz
 
 jobs:
   build:
@@ -21,13 +21,20 @@ jobs:
           UPLOAD_URL="$(jq -r '.release.upload_url' "$GITHUB_EVENT_PATH" | sed -e "s/{?name,label}$/?name=${ARCHIVE_NAME}/")"
           echo "UPLOAD_URL=$UPLOAD_URL" >> $GITHUB_ENV
 
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: armv7-unknown-linux-musleabihf
+
       - name: Build application
         run: |
-          docker run --rm -t -v $HOME/.cargo/registry/:/root/.cargo/registry -v "$(pwd)":/volume clux/muslrust:stable cargo build --release
+          sudo apt update && sudo apt install -y clang llvm
+          export TARGET_CC=clang
+          export TARGET_AR=llvm-ar
+          cargo build --release --target=armv7-unknown-linux-musleabihf
 
       - name: Create archive
         run: |
-          tar -czf $ARCHIVE_NAME -C target/x86_64-unknown-linux-musl/release $APP_NAME
+          tar -czf $ARCHIVE_NAME -C target/armv7-unknown-linux-musleabihf/release $APP_NAME
 
       - name: Upload release asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release_macos.yaml
+++ b/.github/workflows/release_macos.yaml
@@ -1,4 +1,4 @@
-name: Build and upload release (macos)
+name: Build and upload release (macos x86_64)
 
 on:
   release:

--- a/.github/workflows/release_macos_arm.yaml
+++ b/.github/workflows/release_macos_arm.yaml
@@ -1,4 +1,4 @@
-name: Build and upload release (linux x86_64)
+name: Build and upload release (macos arm64)
 
 on:
   release:
@@ -6,11 +6,11 @@ on:
 
 env:
   APP_NAME: gdrive
-  ARCHIVE_NAME: gdrive_linux-x64.tar.gz
+  ARCHIVE_NAME: gdrive_macos-arm64.tar.gz
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
@@ -23,11 +23,9 @@ jobs:
 
       - name: Build application
         run: |
-          docker run --rm -t -v $HOME/.cargo/registry/:/root/.cargo/registry -v "$(pwd)":/volume clux/muslrust:stable cargo build --release
-
-      - name: Create archive
-        run: |
-          tar -czf $ARCHIVE_NAME -C target/x86_64-unknown-linux-musl/release $APP_NAME
+          rustup target add aarch64-apple-darwin
+          cargo build --release --target=aarch64-apple-darwin
+          tar -czf $ARCHIVE_NAME -C target/aarch64-apple-darwin/release/ $APP_NAME
 
       - name: Upload release asset
         uses: actions/upload-release-asset@v1

--- a/src/common/drive_file.rs
+++ b/src/common/drive_file.rs
@@ -61,7 +61,7 @@ pub enum DocType {
 }
 
 impl DocType {
-    const IMPORT_EXTENSION_MAP: &[(FileExtension, DocType)] = &[
+    const IMPORT_EXTENSION_MAP: &'static [(FileExtension, DocType)] = &[
         (FileExtension::Doc, DocType::Document),
         (FileExtension::Docx, DocType::Document),
         (FileExtension::Odt, DocType::Document),


### PR DESCRIPTION
This should fix issues #63 #79 and #101 by providing the respective release build workflow configs.

I don't have time for this, but managing many yaml files is cumbersome, a rewrite of CI using <https://github.com/houseabsolute/actions-rust-cross> is in order? Then even more platforms can be targeted.