### PR TITLE
docs: add missing argument in basic_usage.md

### DIFF
--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -22,7 +22,7 @@ A single file can be downloaded with
 ```
 gdrive files download <file id>
 ```
-however, this will only work for files with "binary content" and not Google Docs files. To download files that can be edited with Google Docs it's necessary to use the `gdrive export <file id> <output file>` command.
+however, this will only work for files with "binary content" and not Google Docs files. To download files that can be edited with Google Docs it's necessary to use the `gdrive files export <file id> <output file>` command.
 
 ## Downloading directories
 Downloading a directory is done by the same command as downloading a file, but with the `--recursive` flag:


### PR DESCRIPTION
`files` is necessary for `export`.