### PR TITLE
Recursive download: add export

### DIFF
--- a/src/common/drive_file.rs
+++ b/src/common/drive_file.rs
@@ -120,6 +120,14 @@ impl DocType {
         }
     }
 
+    pub fn default_office_export_type(&self) -> FileExtension {
+        match self {
+            DocType::Document => FileExtension::Docx,
+            DocType::Spreadsheet => FileExtension::Xlsx,
+            DocType::Presentation => FileExtension::Pptx,
+        }
+    }
+
     pub fn can_export_to(&self, extension: &FileExtension) -> bool {
         self.supported_export_types().contains(extension)
     }

--- a/src/common/file_tree_drive.rs
+++ b/src/common/file_tree_drive.rs
@@ -127,8 +127,14 @@ impl Folder {
                 let f = File::from_file(&file, &folder).await?;
                 let node = Node::FileNode(f);
                 children.push(node);
-            } else {
-                // Skip documents
+            } else if drive_file::DocType::from_mime_type(
+                file.mime_type.as_deref().unwrap_or_default(),
+            )
+            .is_some()
+            {
+                let f = File::from_google_doc(&file, &folder).await?;
+                let node = Node::FileNode(f);
+                children.push(node);
             }
         }
 
@@ -199,6 +205,7 @@ pub struct File {
     pub parent: Folder,
     pub drive_id: String,
     pub md5: Option<String>,
+    pub mime_type: Option<String>,
 }
 
 impl File {
@@ -217,13 +224,46 @@ impl File {
             parent: parent.clone(),
             drive_id: file_id,
             md5,
+            mime_type: file.mime_type.clone(),
         };
 
         Ok(file)
     }
 
+    pub async fn from_google_doc(
+        file: &google_drive3::api::File,
+        parent: &Folder,
+    ) -> Result<File, Error> {
+        let name = file.name.clone().ok_or(Error::MissingFileName)?;
+        let file_id = file.id.clone().ok_or(Error::MissingFileId)?;
+
+        let doc_type = drive_file::DocType::from_mime_type(
+            file.mime_type.as_deref().unwrap_or_default(),
+        );
+        let export_ext = doc_type
+            .map(|dt| dt.default_office_export_type().to_string())
+            .unwrap_or_default();
+        let export_name = format!("{}.{}", name, export_ext);
+
+        Ok(File {
+            name: export_name,
+            size: 0,
+            parent: parent.clone(),
+            drive_id: file_id,
+            md5: None,
+            mime_type: file.mime_type.clone(),
+        })
+    }
+
     pub fn relative_path(&self) -> PathBuf {
         self.parent.relative_path().join(&self.name)
+    }
+
+    pub fn is_google_doc(&self) -> bool {
+        self.mime_type
+            .as_deref()
+            .and_then(drive_file::DocType::from_mime_type)
+            .is_some()
     }
 }
 

--- a/src/files/download.rs
+++ b/src/files/download.rs
@@ -1,4 +1,5 @@
 use crate::common::drive_file;
+use crate::common::drive_file::DocType;
 use crate::common::file_tree_drive;
 use crate::common::file_tree_drive::FileTreeDrive;
 use crate::common::hub_helper;
@@ -167,12 +168,28 @@ pub async fn download_directory(
                 continue;
             }
 
-            let body = download_file(&hub, &file.drive_id)
-                .await
-                .map_err(Error::DownloadFile)?;
+            if file.is_google_doc() {
+                let doc_type = DocType::from_mime_type(
+                    file.mime_type.as_deref().unwrap_or_default(),
+                )
+                .unwrap();
+                let export_ext = doc_type.default_office_export_type();
+                let mime_type = export_ext.get_export_mime().unwrap();
 
-            println!("Downloading file '{}'", file_path.display());
-            save_body_to_file(body, &abs_file_path, file.md5.clone()).await?;
+                let body = files::export::export_file(&hub, &file.drive_id, &mime_type)
+                    .await
+                    .map_err(Error::ExportFile)?;
+
+                println!("Exporting {} '{}'", doc_type, file_path.display());
+                save_body_to_file(body, &abs_file_path, None).await?;
+            } else {
+                let body = download_file(&hub, &file.drive_id)
+                    .await
+                    .map_err(Error::DownloadFile)?;
+
+                println!("Downloading file '{}'", file_path.display());
+                save_body_to_file(body, &abs_file_path, file.md5.clone()).await?;
+            }
         }
     }
 
@@ -204,6 +221,7 @@ pub enum Error {
     Hub(hub_helper::Error),
     GetFile(google_drive3::Error),
     DownloadFile(google_drive3::Error),
+    ExportFile(google_drive3::Error),
     MissingFileName,
     FileExists(PathBuf),
     IsDirectory(String),
@@ -231,6 +249,7 @@ impl Display for Error {
             Error::Hub(err) => write!(f, "{}", err),
             Error::GetFile(err) => write!(f, "Failed getting file: {}", err),
             Error::DownloadFile(err) => write!(f, "Failed to download file: {}", err),
+            Error::ExportFile(err) => write!(f, "Failed to export file: {}", err),
             Error::MissingFileName => write!(f, "File does not have a name"),
             Error::FileExists(path) => write!(
                 f,

--- a/src/files/download.rs
+++ b/src/files/download.rs
@@ -1,7 +1,5 @@
 use crate::common::drive_file;
 use crate::common::drive_file::DocType;
-use crate::common::file_tree_drive;
-use crate::common::file_tree_drive::FileTreeDrive;
 use crate::common::hub_helper;
 use crate::common::md5_writer::Md5Writer;
 use crate::files;
@@ -137,68 +135,100 @@ pub async fn download_directory(
     file: &google_drive3::api::File,
     config: &Config,
 ) -> Result<(), Error> {
-    let tree = FileTreeDrive::from_file(&hub, &file)
-        .await
-        .map_err(Error::CreateFileTree)?;
-
-    let tree_info = tree.info();
-
-    println!(
-        "Found {} files in {} directories with a total size of {}",
-        tree_info.file_count,
-        tree_info.folder_count,
-        human_bytes(tree_info.total_file_size as f64)
-    );
-
     let root_path = config.canonical_destination_root()?;
+    let dir_name = file.name.clone().ok_or(Error::MissingFileName)?;
+    let dir_path = PathBuf::from(&dir_name);
 
-    for folder in &tree.folders() {
-        let folder_path = folder.relative_path();
-        let abs_folder_path = root_path.join(&folder_path);
-
-        println!("Creating directory {}", folder_path.display());
-        fs::create_dir_all(&abs_folder_path)
-            .map_err(|err| Error::CreateDirectory(abs_folder_path, err))?;
-
-        for file in folder.files() {
-            let file_path = file.relative_path();
-            let abs_file_path = root_path.join(&file_path);
-
-            if local_file_is_identical(&abs_file_path, &file) {
-                continue;
-            }
-
-            if file.is_google_doc() {
-                let doc_type = DocType::from_mime_type(
-                    file.mime_type.as_deref().unwrap_or_default(),
-                )
-                .unwrap();
-                let export_ext = doc_type.default_office_export_type();
-                let mime_type = export_ext.get_export_mime().unwrap();
-
-                let body = files::export::export_file(&hub, &file.drive_id, &mime_type)
-                    .await
-                    .map_err(Error::ExportFile)?;
-
-                println!("Exporting {} '{}'", doc_type, file_path.display());
-                save_body_to_file(body, &abs_file_path, None).await?;
-            } else {
-                let body = download_file(&hub, &file.drive_id)
-                    .await
-                    .map_err(Error::DownloadFile)?;
-
-                println!("Downloading file '{}'", file_path.display());
-                save_body_to_file(body, &abs_file_path, file.md5.clone()).await?;
-            }
-        }
-    }
+    let mut stats = DownloadStats::default();
+    download_directory_recursive(hub, file, &root_path, &dir_path, &mut stats).await?;
 
     println!(
         "Downloaded {} files in {} directories with a total size of {}",
-        tree_info.file_count,
-        tree_info.folder_count,
-        human_bytes(tree_info.total_file_size as f64)
+        stats.file_count,
+        stats.folder_count,
+        human_bytes(stats.total_file_size as f64)
     );
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct DownloadStats {
+    file_count: u64,
+    folder_count: u64,
+    total_file_size: u64,
+}
+
+#[async_recursion]
+async fn download_directory_recursive(
+    hub: &Hub,
+    dir_file: &google_drive3::api::File,
+    root_path: &PathBuf,
+    dir_path: &PathBuf,
+    stats: &mut DownloadStats,
+) -> Result<(), Error> {
+    let abs_dir_path = root_path.join(dir_path);
+    println!("Creating directory {}", dir_path.display());
+    fs::create_dir_all(&abs_dir_path)
+        .map_err(|err| Error::CreateDirectory(abs_dir_path.clone(), err))?;
+    stats.folder_count += 1;
+
+    let file_id = dir_file.id.clone().ok_or(Error::MissingFileName)?;
+    let children = files::list::list_files(
+        hub,
+        &files::list::ListFilesConfig {
+            query: files::list::ListQuery::FilesInFolder { folder_id: file_id },
+            order_by: Default::default(),
+            max_files: usize::MAX,
+        },
+    )
+    .await
+    .map_err(Error::ListFiles)?;
+
+    for child in &children {
+        if drive_file::is_directory(child) {
+            let child_name = child.name.clone().ok_or(Error::MissingFileName)?;
+            let child_path = dir_path.join(&child_name);
+            download_directory_recursive(hub, child, root_path, &child_path, stats).await?;
+        } else if drive_file::is_binary(child) {
+            let file_name = child.name.clone().ok_or(Error::MissingFileName)?;
+            let file_path = dir_path.join(&file_name);
+            let abs_file_path = root_path.join(&file_path);
+
+            if abs_file_path.exists() {
+                let file_md5 = compute_md5_from_path(&abs_file_path).unwrap_or_default();
+                if child.md5_checksum.as_deref() == Some(&file_md5) {
+                    continue;
+                }
+            }
+
+            let body = download_file(hub, child.id.as_deref().unwrap_or_default())
+                .await
+                .map_err(Error::DownloadFile)?;
+
+            println!("Downloading file '{}'", file_path.display());
+            save_body_to_file(body, &abs_file_path, child.md5_checksum.clone()).await?;
+            stats.file_count += 1;
+            stats.total_file_size += child.size.unwrap_or(0) as u64;
+        } else if let Some(doc_type) = DocType::from_mime_type(
+            child.mime_type.as_deref().unwrap_or_default(),
+        ) {
+            let file_name = child.name.clone().ok_or(Error::MissingFileName)?;
+            let export_ext = doc_type.default_office_export_type();
+            let export_name = format!("{}.{}", file_name, export_ext);
+            let file_path = dir_path.join(&export_name);
+            let abs_file_path = root_path.join(&file_path);
+
+            let mime_type = export_ext.get_export_mime().unwrap();
+            let body = files::export::export_file(hub, child.id.as_deref().unwrap_or_default(), &mime_type)
+                .await
+                .map_err(Error::ExportFile)?;
+
+            println!("Exporting {} '{}'", doc_type, file_path.display());
+            save_body_to_file(body, &abs_file_path, None).await?;
+            stats.file_count += 1;
+        }
+    }
 
     Ok(())
 }
@@ -222,6 +252,7 @@ pub enum Error {
     GetFile(google_drive3::Error),
     DownloadFile(google_drive3::Error),
     ExportFile(google_drive3::Error),
+    ListFiles(files::list::Error),
     MissingFileName,
     FileExists(PathBuf),
     IsDirectory(String),
@@ -232,7 +263,6 @@ pub enum Error {
     RenameFile(io::Error),
     ReadChunk(hyper::Error),
     WriteChunk(io::Error),
-    CreateFileTree(file_tree_drive::Error),
     DestinationPathDoesNotExist(PathBuf),
     DestinationPathNotADirectory(PathBuf),
     CanonicalizeDestinationPath(PathBuf, io::Error),
@@ -250,6 +280,7 @@ impl Display for Error {
             Error::GetFile(err) => write!(f, "Failed getting file: {}", err),
             Error::DownloadFile(err) => write!(f, "Failed to download file: {}", err),
             Error::ExportFile(err) => write!(f, "Failed to export file: {}", err),
+            Error::ListFiles(err) => write!(f, "Failed to list files: {}", err),
             Error::MissingFileName => write!(f, "File does not have a name"),
             Error::FileExists(path) => write!(
                 f,
@@ -280,7 +311,6 @@ impl Display for Error {
             Error::RenameFile(err) => write!(f, "Failed to rename file: {}", err),
             Error::ReadChunk(err) => write!(f, "Failed read from stream: {}", err),
             Error::WriteChunk(err) => write!(f, "Failed write to file: {}", err),
-            Error::CreateFileTree(err) => write!(f, "Failed to create file tree: {}", err),
             Error::DestinationPathDoesNotExist(path) => {
                 write!(f, "Destination path '{}' does not exist", path.display())
             }
@@ -419,24 +449,6 @@ fn err_if_md5_mismatch(expected: Option<String>, actual: String) -> Result<(), E
             expected: expected.unwrap_or_default(),
             actual,
         })
-    }
-}
-
-fn local_file_is_identical(path: &PathBuf, file: &file_tree_drive::File) -> bool {
-    if path.exists() {
-        let file_md5 = compute_md5_from_path(path).unwrap_or_else(|err| {
-            eprintln!(
-                "Warning: Error while computing md5 of '{}': {}",
-                path.display(),
-                err
-            );
-
-            String::new()
-        });
-
-        file.md5.clone().map(|md5| md5 == file_md5).unwrap_or(false)
-    } else {
-        false
     }
 }
 


### PR DESCRIPTION
The [docs](https://github.com/glotlabs/gdrive/blob/855155649a5911565c9134eac6a1f9b9bf235494/docs/basic_usage.md) mentions a limitation of the recursive download:

> Downloading directories
> Downloading a directory is done by the same command as downloading a file, but with the --recursive flag:
>
> `gdrive files download --recursive <file id (directory)>`
> this will create a directory with the same name as the Google Drive directory and copy all files recursively. It may take a while before you get any output, but you should get a status on which directories and files are created and downloaded.
> 
> **Note: any Google Docs files will be silently ignored when doing this.**

This PR updates the recursive download to automatically export docs to docx, spreadsheets to xlsx, and presentations to pptx.

With this addition, `files download --recursive` can be used as a full backup tool to save Google Drive as local files.

The PR also changes the process from "walk the tree with no output for a long time, then download" to "walk the tree and download at the same time" (this is done in a separate commit, so can easily be removed, although I think it is more useful this way)..